### PR TITLE
Update the readme to reflect that params to middleware.use must be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Routing
 A mini router middleware is bundled for Rails 2.x support.
 
     # config/environments/development.rb
-    config.middleware.use MailView::Mapper, Notifier::Preview
+    config.middleware.use MailView::Mapper, [Notifier::Preview]
 
 For Rails³ you can map the app inline in your routes config.
 


### PR DESCRIPTION
Update the readme to reflect that params to middleware.use must be an array in Rails 2.3.x in order to prevent the typical "ArgumentError: wrong number of arguments (0 for 1)"
