### PR TITLE
Include Tilt as a dependency in .gemspec

### DIFF
--- a/mail_view.gemspec
+++ b/mail_view.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'tilt', ['>= 1.3.3']
 
-  s.files = Dir["#{File.dirname(__FILE__)}/*/**"]
+  s.files = Dir["#{File.dirname(__FILE__)}/*/**/*"]
 end

--- a/mail_view.gemspec
+++ b/mail_view.gemspec
@@ -6,5 +6,7 @@ Gem::Specification.new do |s|
   s.summary = 'Visual email testing'
   s.homepage = 'https://github.com/37signals/mail_view'
 
+  s.add_dependency 'tilt', ['>= 1.3.3']
+
   s.files = Dir["#{File.dirname(__FILE__)}/*/**"]
 end


### PR DESCRIPTION
The latest version is specified, but this may need to be adjusted
