### PR TITLE
Add !important to body style margin-top to avoid email styles overriding it.

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -52,7 +52,7 @@
   }
 
   body {
-    margin-top: 96px;
+    margin-top: 96px !important;
   }
 </style>
 <div id="message_headers">


### PR DESCRIPTION
If the email being previewed has an inline style setting the margin, then it overrode mail_view's style and got hidden below the #message_headers div, added !important to force magin-top back to 96px.
