### PR TITLE
Show reply-to header if set

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -60,6 +60,11 @@
     <dt>From:</dt>
     <dd><%= mail.from %></dd>
 
+    <% if mail.reply_to %>
+      <dt>Reply-To:</dt>
+      <dd><%= mail.reply_to %></dd>
+    <% end %>
+
     <dt>Subject:</dt>
     <dd><strong><%= mail.subject %></strong></dd>
 


### PR DESCRIPTION
If there's a value for the reply-to header, then show it. This will require changes to the styles to accommodate headers of different heights. Those changes are in a separate pull request.
