### PR TITLE
Use an iframe to embed HTML emails

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -2,26 +2,31 @@
   <meta http-equiv="Content-Type" content="text/html; charset=<%= body_part.charset %>" />
 </head>
 <style type="text/css">
+  * { margin: 0; padding: 0; }
+
+  body {
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+    padding: 20px;
+  }
+
   #message_headers {
-    width: 100%;
-    padding: 10px 0 0 0;
-    margin: 0;
-    background: #fff;
-    font-size: 12px;
-    font-family: "Lucida Grande";
-    border-bottom: 1px solid #dedede;
-    overflow: hidden;
+    background: white;
+    font: 12px/16px "Lucida Grande";
   }
 
   #message_headers dl {
-    float: left;
-    margin: 0 0 10px 0;
-    padding: 0;
+    display: block;
+    border-bottom: 1px solid #dedede;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    overflow: hidden;
   }
 
   #message_headers dt {
-    width: 80px;
-    padding: 1px;
+    width: 60px;
     float: left;
     text-align: right;
     font-weight: bold;
@@ -29,24 +34,31 @@
   }
 
   #message_headers dd {
-    margin-left: 90px;
-    padding: 1px;
+    margin-left: 70px; /* 60px + 10px */
   }
 
   #message_headers p.alternate {
-    float: right;
-    margin: 0;
+    position: absolute;
+    top: 20px;
+    right: 20px;
   }
 
   #message_headers p.alternate a {
     color: #09c;
   }
 
+  iframe#message_body {
+    border: 0;
+    width: 100%;
+    -webkit-flex: 1 1 auto;
+    flex: 1 1 auto;
+  }
+
   pre#message_body {
-    padding: 10px;
     white-space: pre-wrap;
   }
 </style>
+
 <div id="message_headers">
   <dl>
     <% if mail.respond_to?(:smtp_envelope_from) && mail.from != mail.smtp_envelope_from %>
@@ -89,7 +101,7 @@
 </div>
 
 <% if body_part.content_type && body_part.content_type.match(/text\/html/) %>
-  <%= body_part.body %>
+<iframe id="message_body" src="<%= body_only_path %>"></iframe>
 <% else %>
 <pre id="message_body"><%= body_part.body %></pre>
 <% end %>

--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -28,6 +28,7 @@
   #message_headers dt {
     width: 60px;
     float: left;
+    clear: left;
     text-align: right;
     font-weight: bold;
     color: #7f7f7f;

--- a/test/test_mail_view.rb
+++ b/test/test_mail_view.rb
@@ -68,6 +68,10 @@ class TestMailView < Test::Unit::TestCase
     Preview
   end
 
+  def iframe_src_match(action)
+    /<iframe[^>]* src="#{Regexp.escape(action)}"[^>]*><\/iframe>/
+  end
+
   def test_index
     get '/'
     assert last_response.ok?
@@ -85,38 +89,49 @@ class TestMailView < Test::Unit::TestCase
   def test_plain_text_message
     get '/plain_text_message'
     assert last_response.ok?
-
     assert_match(/Hello/, last_response.body)
   end
 
   def test_html_message
     get '/html_message'
     assert last_response.ok?
+    assert_match(iframe_src_match('/html_message.html?body=1'), last_response.body)
 
+    get '/html_message.html?body=1'
+    assert last_response.ok?
     assert_match(/<h1>Hello<\/h1>/, last_response.body)
   end
 
   def test_nested_multipart_message
     get '/nested_multipart_message'
     assert last_response.ok?
+    assert_match(iframe_src_match('/nested_multipart_message.html?body=1'), last_response.body)
 
+    get '/nested_multipart_message?body=1'
+    assert last_response.ok?
     assert_match(/<h1>Hello<\/h1>/, last_response.body)
   end
 
   def test_multipart_alternative
     get '/multipart_alternative'
     assert last_response.ok?
-
-    assert_match(/<h1>This is HTML<\/h1>/, last_response.body)
+    assert_match(iframe_src_match('/multipart_alternative.html?body=1'), last_response.body)
     assert_match(/View plain text version/, last_response.body)
+
+    get '/multipart_alternative.html?body=1'
+    assert last_response.ok?
+    assert_match(/<h1>This is HTML<\/h1>/, last_response.body)
   end
 
   def test_multipart_alternative_as_html
     get '/multipart_alternative.html'
     assert last_response.ok?
-
-    assert_match(/<h1>This is HTML<\/h1>/, last_response.body)
+    assert_match(iframe_src_match('/multipart_alternative.html?body=1'), last_response.body)
     assert_match(/View plain text version/, last_response.body)
+
+    get '/multipart_alternative.html?body=1'
+    assert last_response.ok?
+    assert_match(/<h1>This is HTML<\/h1>/, last_response.body)
   end
 
   def test_multipart_alternative_as_text
@@ -131,16 +146,22 @@ class TestMailView < Test::Unit::TestCase
     def test_tmail_html_message
       get '/tmail_html_message'
       assert last_response.ok?
+      assert_match(iframe_src_match('/tmail_html_message.html?body=1'), last_response.body)
 
+      get '/tmail_html_message.html?body=1'
+      assert last_response.ok?
       assert_match(/<h1>Hello<\/h1>/, last_response.body)
     end
 
     def test_tmail_multipart_alternative
       get '/tmail_multipart_alternative'
       assert last_response.ok?
-
-      assert_match(/<h1>This is HTML<\/h1>/, last_response.body)
       assert_match(/View plain text version/, last_response.body)
+      assert_match(iframe_src_match('/tmail_multipart_alternative.html?body=1'), last_response.body)
+
+      get '/tmail_multipart_alternative.html?body=1'
+      assert last_response.ok?
+      assert_match(/<h1>Hello<\/h1>/, last_response.body)
     end
   end
 end


### PR DESCRIPTION
This changeset allows for more accurate previewing of HTML emails which style the body element. Instead of inserting the HTML email directly into the page we embed it via an iframe.

It has the same goal as #21 but is a smaller patchset, and is against the current master.

Before:

![html-embed-email](https://f.cloud.github.com/assets/153/138423/6eff4fa2-71a4-11e2-89d0-1e46823c182f.png)

The browser has merged the styles in the embedded HTML email into the top level doc, creating a weird mish-mash.

After:

![html-iframe-email](https://f.cloud.github.com/assets/153/138420/fbc5432a-71a3-11e2-8904-cdbae310bd4a.png)

Everything's self-contained, just like in an email client, and stretches & scrolls to the full height thanks to flexbox. The styles have also been simplified and slightly improved to more closely match Mail.app.
