### PR TITLE
Fallback font for non-Mac users

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -8,7 +8,7 @@
     margin: 0;
     background: #fff;
     font-size: 12px;
-    font-family: "Lucida Grande";
+    font-family: "Lucida Grande", sans-serif;
     border-bottom: 1px solid #dedede;
     overflow: hidden;
   }


### PR DESCRIPTION
Closes #27

Pretty simple: just add a fallback font family.  Without this change, the headers (to, from, etc) are in Times New Roman on Linux, which looks really out of place.

Thanks for maintaining MailView!
