### PR TITLE
Shows display names for mail template

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -55,11 +55,11 @@
     <% end %>
 
     <dt>From:</dt>
-    <dd><%= mail.from %></dd>
+    <dd><%= Rack::Utils.escape_html(mail.header['from'].to_s) %></dd>
 
     <% if mail.reply_to %>
       <dt>Reply-To:</dt>
-      <dd><%= mail.reply_to %></dd>
+      <dd><%= Rack::Utils.escape_html(mail.header['reply-to'].to_s) %></dd>
     <% end %>
 
     <dt>Subject:</dt>
@@ -74,7 +74,7 @@
     <% end %>
 
     <dt>To:</dt>
-    <dd><%= mail.to %></dd>
+    <dd><%= Rack::Utils.escape_html(mail.header['to'].to_s) %></dd>
   </dl>
 
   <% if mail.multipart? %>


### PR DESCRIPTION
I.e., From: Josh &lt;josh@signals.com&gt; instead of just
From: &lt;josh@signals.com&gt;
Implemented for from, to, reply-to
Checked with Mail and Tmail
