### PR TITLE
Use headers to show what the mail will look like in your inbox

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -55,7 +55,7 @@
     <% end %>
 
     <dt>From:</dt>
-    <dd><%= mail.from %></dd>
+    <dd><%= mail.header['From'] %></dd>
 
     <% if mail.reply_to %>
       <dt>Reply-To:</dt>
@@ -74,7 +74,7 @@
     <% end %>
 
     <dt>To:</dt>
-    <dd><%= mail.to %></dd>
+    <dd><%= mail.header['To'] %></dd>
   </dl>
 
   <% if mail.multipart? %>


### PR DESCRIPTION
Message.to / from will only show the email parts, and not the name, if you've added one. Feels a bit "nicer" to show this in there, because there's some cognitive overhead of going - where's the name bits?

i.e.,
message.to = 'Bob Ross bob@bobross.com'

message.to => 'bob@bobross.com'
message.header['To'] => 'Bob Ross bob@bobross.com'
