### PR TITLE
Remove Attachments from Render

### DIFF
--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -81,6 +81,8 @@ class MailView
     def render_mail(name, mail, format = nil)
       body_part = mail
 
+      puts body_part.inspect
+
       if mail.multipart?
         content_type = Rack::Mime.mime_type(format)
         body_part = if mail.respond_to?(:all_parts)


### PR DESCRIPTION
The PDF attachment we have on our emails looks like hot garbage in the MailView render. Need to rip that bad boy off!
