### PR TITLE
Updated the gemfile to use https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       tilt
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     i18n (0.6.1)
     mail (2.4.4)


### PR DESCRIPTION
To get rid of warnings on bundle install, eg:

The source :rubygems is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
