### PR TITLE
Made mail_view use mail interceptors (if using mail)

### DIFF
--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -79,6 +79,8 @@ class MailView
     end
 
     def render_mail(name, mail, format = nil)
+      Mail.inform_interceptors(mail) if defined? Mail
+
       body_part = mail
 
       if mail.multipart?


### PR DESCRIPTION
We use an actionmailer/mail interceptor in our app to inline css. Pages generated by mail_view don't run any interceptors, so the view we see is not the same as what's actually delivered in an email.

I'm not entirely sure this change is a good idea, it's adding a new dependency on mail (whereas at the moment mail_view only relies on tilt) and it moves slightly away from the pure way of rendering emails like web page views. But having something like this is really important if mail_view is to give an accurate representation of an email
