### PR TITLE
Allow passing in of URL parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Since most emails do something interesting with database data, you'll need to wr
       user = Struct.new(:email, :name).new('name@example.com', 'Jill Smith')
       mail = UserMailer.forgot_password(user)
     end
+
+    # Use passed in URL parameters
+    def mail_user
+      user = User.find(params['user_id'])
+      mail = UserMailer.say_hi(user)
+    end
   end
 ```
 

--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -7,6 +7,8 @@ require 'rack/request'
 class MailView
   autoload :Mapper, 'mail_view/mapper'
 
+  attr_accessor :params
+
   class << self
     def default_email_template_path
       File.expand_path('../mail_view/email.html.erb', __FILE__)
@@ -33,6 +35,7 @@ class MailView
 
     elsif request.path =~ /([\w_]+)(\.\w+)?\z/
       name, ext = $1, $2
+      self.params = request.params
       format = Rack::Mime.mime_type(ext, nil)
       missing_format = ext && format.nil?
 
@@ -52,7 +55,8 @@ class MailView
         # Otherwise, show our message headers & frame the body.
         else
           part = find_preferred_part(mail, [format, 'text/html', 'text/plain'])
-          ok email_template.render(Object.new, :name => name, :mail => mail, :part => part, :part_url => part_body_url(part))
+          part_url = part_body_url(part) + format_params(params)
+          ok email_template.render(Object.new, :name => name, :mail => mail, :part => part, :part_url => part_url)
         end
       else
         not_found
@@ -111,6 +115,13 @@ class MailView
 
     def part_body_url(part)
       '?part=%s' % Rack::Utils.escape([part.main_type, part.sub_type].compact.join('/'))
+    end
+
+    def format_params(params)
+      params.inject("") {|m,o|
+        parm = "#{o[0]}=#{Rack::Utils.escape(o[1])}"
+        "#{m}&#{parm}"
+      }
     end
 
     def find_part(mail, matching_content_type)

--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -55,8 +55,12 @@ class MailView
         # Otherwise, show our message headers & frame the body.
         else
           part = find_preferred_part(mail, [format, 'text/html', 'text/plain'])
-          part_url = part_body_url(part) + format_params(params)
-          ok email_template.render(Object.new, :name => name, :mail => mail, :part => part, :part_url => part_url)
+          ok email_template.render(Object.new,
+                                   :name    => name,
+                                   :mail    => mail,
+                                   :part    => part,
+                                   :part_url=> part_body_url(part),
+                                   :params  => format_params(params))
         end
       else
         not_found

--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -84,15 +84,15 @@
     <% if mail.multipart? %>
       <dd>
         <select onchange="top.messageBody.location=this.options[this.selectedIndex].value;">
-          <option value="?part=text%2Fhtml">View as HTML email</option>
-          <option value="?part=text%2Fplain">View as plain-text email</option>
+          <option value="?part=text%2Fhtml<%=params%>">View as HTML email</option>
+          <option value="?part=text%2Fplain<%=params%>">View as plain-text email</option>
         </select>
       </dd>
     <% end %>
   </dl>
 </header>
 
-<iframe seamless name="messageBody" src="<%= part_url %>"></iframe>
+<iframe seamless name="messageBody" src="<%= part_url + params %>"></iframe>
 
 </body>
 </html>

--- a/test/test_mail_view.rb
+++ b/test/test_mail_view.rb
@@ -131,8 +131,8 @@ class TestMailView < Test::Unit::TestCase
     Preview
   end
 
-  def iframe_src_match(content_type)
-    /<iframe[^>]* src="\?part=#{Regexp.escape(Rack::Utils.escape(content_type))}"[^>]*><\/iframe>/
+  def iframe_src_match(content_type, params="")
+    /<iframe[^>]* src="\?part=#{Regexp.escape(Rack::Utils.escape(content_type))}#{params}"[^>]*><\/iframe>/
   end
 
   def unescaped_body
@@ -206,6 +206,12 @@ class TestMailView < Test::Unit::TestCase
     get '/html_message?part=text%2Fhtml'
     assert last_response.ok?
     assert_equal '<h1>Hello</h1>', last_response.body
+  end
+
+  def test_html_message_with_params
+    get '/html_message?user_id=42'
+    assert last_response.ok?
+    assert_match iframe_src_match('text/html',"&user_id=42"), last_response.body
   end
 
   def test_nested_multipart_message


### PR DESCRIPTION
This change allows the passing in of URL parameters so you can use them to find objects dynamically without having to create or hard-code fixture data. I added an example in the README and a test to cover the basics of how it works.
