### PR TITLE
Changed descriptions of the email part, in the view, so they make more sense to users

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -83,9 +83,10 @@
 
     <% if mail.multipart? %>
       <dd>
+        <dt>Email Part:</dt>
         <select onchange="top.messageBody.location=this.options[this.selectedIndex].value;">
-          <option value="?part=text%2Fhtml">View as HTML email</option>
-          <option value="?part=text%2Fplain">View as plain-text email</option>
+          <option value="?part=text%2Fhtml">HTML</option>
+          <option value="?part=text%2Fplain" selected>Plain-text</option>
         </select>
       </dd>
     <% end %>

--- a/test/test_mail_view.rb
+++ b/test/test_mail_view.rb
@@ -172,7 +172,7 @@ class TestMailView < Test::Unit::TestCase
     get '/plain_text_message'
     assert last_response.ok?
     assert_match iframe_src_match(''), last_response.body
-    assert_no_match %r(View as), last_response.body
+    assert_no_match %r(Email Part), last_response.body
 
     get '/plain_text_message?part='
     assert last_response.ok?
@@ -183,7 +183,7 @@ class TestMailView < Test::Unit::TestCase
     get '/plain_text_message', {}, 'SCRIPT_NAME' => '/boom'
     assert last_response.ok?
     assert_match iframe_src_match(''), last_response.body
-    assert_no_match %r(View as), last_response.body
+    assert_no_match %r(Email Part), last_response.body
 
     get '/boom/plain_text_message?part='
     assert last_response.ok?
@@ -201,7 +201,7 @@ class TestMailView < Test::Unit::TestCase
     get '/html_message'
     assert last_response.ok?
     assert_match iframe_src_match('text/html'), last_response.body
-    assert_no_match %r(View as), last_response.body
+    assert_no_match %r(Email Part), last_response.body
 
     get '/html_message?part=text%2Fhtml'
     assert last_response.ok?
@@ -212,7 +212,7 @@ class TestMailView < Test::Unit::TestCase
     get '/nested_multipart_message'
     assert last_response.ok?
     assert_match iframe_src_match('text/html'), last_response.body
-    assert_match %r(View as), last_response.body
+    assert_match %r(Email Part), last_response.body
 
     get '/nested_multipart_message?part=text%2Fhtml'
     assert last_response.ok?
@@ -223,7 +223,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_alternative'
     assert last_response.ok?
     assert_match iframe_src_match('text/html'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
 
     get '/multipart_alternative?part=text%2Fhtml'
     assert last_response.ok?
@@ -234,7 +234,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_alternative.html'
     assert last_response.ok?
     assert_match iframe_src_match('text/html'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
 
     get '/multipart_alternative.html?part=text%2Fhtml'
     assert last_response.ok?
@@ -245,7 +245,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_alternative.txt'
     assert last_response.ok?
     assert_match iframe_src_match('text/plain'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
 
     get '/multipart_alternative.txt?part=text%2Fplain'
     assert last_response.ok?
@@ -256,7 +256,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_alternative_text_default'
     assert last_response.ok?
     assert_match iframe_src_match('text/plain'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
 
     get '/multipart_alternative_text_default?part=text%2Fplain'
     assert last_response.ok?
@@ -267,7 +267,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_mixed_with_text_and_attachment'
     assert last_response.ok?
     assert_match iframe_src_match('text/plain'), last_response.body
-    #assert_no_match %r(View as), last_response.body
+    #assert_no_match %r(Email Part), last_response.body
     assert_match 'checkbox.png', last_response.body
 
     get '/multipart_mixed_with_text_and_attachment?part=text%2Fplain'
@@ -279,7 +279,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_mixed_with_multipart_alternative_and_attachment'
     assert last_response.ok?
     assert_match iframe_src_match('text/html'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
     assert_match 'checkbox.png', last_response.body
 
     get '/multipart_mixed_with_multipart_alternative_and_attachment?part=text%2Fhtml'
@@ -291,7 +291,7 @@ class TestMailView < Test::Unit::TestCase
     get '/multipart_mixed_with_multipart_alternative_and_attachment.txt'
     assert last_response.ok?
     assert_match iframe_src_match('text/plain'), last_response.body
-    assert_match 'View as', last_response.body
+    assert_match 'Email Part', last_response.body
     assert_match 'checkbox.png', last_response.body
 
     get '/multipart_mixed_with_multipart_alternative_and_attachment.txt?part=text%2Fplain'
@@ -322,7 +322,7 @@ class TestMailView < Test::Unit::TestCase
       assert last_response.ok?
       body_path = '/tmail_multipart_alternative?part=text%2Fhtml'
       assert_match iframe_src_match('text/html'), last_response.body
-      assert_match 'View as', last_response.body
+      assert_match 'Email Part', last_response.body
 
       get body_path
       assert last_response.ok?


### PR DESCRIPTION
As the gem stands right now, there's a select menu to choose the email part, with the descriptions "View HTML part" and "View plain-text part". The part _not_ currently shown is the visible element in the menu on loading, so for example, if I'm viewing plaintext, the menu shows "View HTML part" on loading. However, this is awkward for two reasons:
1. When I select the menu and try to change to see the html part, I can't, because that's already selected
2. Select menu's usually show the currently selected option. In this case it's showing the element that's _not_ currently selected (eg. on loading I see plaintext but it shows html)

I've changed this so that (on initial load) the element selected matches what's shown, and I've also tidied up the description of the select menu items.
