### PR TITLE
Show all headers in output

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -31,12 +31,40 @@
     padding: 1px;
   }
 
+  dd a {
+    color: #000;
+    text-decoration: none;
+  }
+  dd a:hover {
+    text-decoration: underline;
+  }
+
+
   iframe {
     border: 0;
     width: 100%;
     height: 800px;
   }
+
+  .disp-none {
+    display: none;
+  }
 </style>
+<script>
+var hideOrShowOtherHeaders = function(idToHideOrShow,idOfVerb) {
+  var hideOrShow = document.getElementById(idToHideOrShow);
+  var verb = document.getElementById(idOfVerb);
+
+  if (verb.textContent == 'Show') {
+    verb.textContent = 'Hide';
+    hideOrShow.style.display = 'block';
+  }
+  else {
+    verb.textContent = 'Show';
+    hideOrShow.style.display = 'none';
+  }
+}
+</script>
 </head>
 
 <body>
@@ -74,11 +102,17 @@
     <dt>Subject:</dt>
     <dd><strong><%= mail.subject %></strong></dd>
 
-    <% mail.header.fields.each do |field| %>
-      <% next if %w(from reply-to to cc subject).include?(field.name.downcase) %>
-      <dt><%= field.name %>:</dt>
-      <dd><%= Rack::Utils.escape_html(field.value.to_s) %></dd>
-    <% end %> 
+    <dt>&nbsp;</dt>
+    <dd>
+      <a href='#' onclick="hideOrShowOtherHeaders('all-other-headers','hide-show-other-headers-verb'); return false"><span id='hide-show-other-headers-verb'>Show</span> additional headers&hellip;</a>
+    </dd>
+    <div id="all-other-headers" class="disp-none">
+      <% mail.header.fields.each do |field| %>
+        <% next if %w(from reply-to to cc subject).include?(field.name.downcase) %>
+        <dt><%= field.name %>:</dt>
+        <dd><%= Rack::Utils.escape_html(field.value.to_s) %></dd>
+      <% end %> 
+    </div>
 
     <% unless mail.attachments.nil? || mail.attachments.empty? %>
       <dt>Attachments:</dt>

--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -18,7 +18,7 @@
   }
 
   dt {
-    width: 80px;
+    width: 180px;
     padding: 1px;
     float: left;
     clear: left;
@@ -27,7 +27,7 @@
   }
 
   dd {
-    margin-left: 90px; /* 80px + 10px */
+    margin-left: 190px; /* 80px + 10px */
     padding: 1px;
   }
 
@@ -73,6 +73,12 @@
 
     <dt>Subject:</dt>
     <dd><strong><%= mail.subject %></strong></dd>
+
+    <% mail.header.fields.each do |field| %>
+      <% next if %w(from reply-to to cc subject).include?(field.name.downcase) %>
+      <dt><%= field.name %>:</dt>
+      <dd><%= Rack::Utils.escape_html(field.value.to_s) %></dd>
+    <% end %> 
 
     <% unless mail.attachments.nil? || mail.attachments.empty? %>
       <dt>Attachments:</dt>

--- a/test/test_mail_view.rb
+++ b/test/test_mail_view.rb
@@ -27,6 +27,16 @@ class TestMailView < Test::Unit::TestCase
       end
     end
 
+    def plain_text_message_with_custom_headers
+      Mail.new do
+        to 'Josh Peek <josh@37signals.com>'
+        from 'Test Peek <test@foo.com>'
+        reply_to 'Another Peek <another@foo.com>'
+        header['X-Custom-Header'] = 'custom-header-value'
+        body 'Hello'
+      end
+    end
+
     def tmail_plain_text_message_with_display_names
       TMail::Mail.parse(plain_text_message_with_display_names.to_s)
     end
@@ -196,6 +206,16 @@ class TestMailView < Test::Unit::TestCase
     assert_match 'Test Peek <test@foo.com>', unescaped_body
     assert_match 'Another Peek <another@foo.com>', unescaped_body
   end
+  
+  def test_custom_headers
+    get '/plain_text_message_with_custom_headers'
+    assert_match 'Josh Peek <josh@37signals.com>', unescaped_body
+    assert_match 'Test Peek <test@foo.com>', unescaped_body
+    assert_match 'Another Peek <another@foo.com>', unescaped_body
+    assert_match 'X-Custom-Header', unescaped_body
+    assert_match 'custom-header-value', unescaped_body
+  end
+
 
   def test_html_message
     get '/html_message'


### PR DESCRIPTION
Not sure if this goes against the spirit of this gem, but I found it useful to be able to see all the headers, specific custom ones my mailers are setting.  Needed to increase the `dt` size to fit headers with longer names.  The value 180 was arrived at entirely unscientifically.

If there's a way to make this configurable that I should know about please let me know and I can make it so.
