### PR TITLE
allow select on nested iframe

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -83,7 +83,7 @@
 
     <% if mail.multipart? %>
       <dd>
-        <select onchange="top.messageBody.location=this.options[this.selectedIndex].value;">
+        <select onchange="document.getElementsByName('messageBody')[0].src=this.options[this.selectedIndex].value;">
           <option value="?part=text%2Fhtml">View as HTML email</option>
           <option value="?part=text%2Fplain">View as plain-text email</option>
         </select>


### PR DESCRIPTION
When mail_view is embedded in an outer iframe, the multipart select  dropdown doesnt work. This fix corrects it.

I'm using the gem different from you intended. My admin page (using active_admin) allows a preview of an outgoing email newsletter, in a show view:

```
<iframe src="/admin/mail_view/newsletter" />
```

Sorry I didnt add a test for this change, I didn't know how or where to add it. Cheers.
