### PR TITLE
Pass request object to #build_mail

### DIFF
--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -37,7 +37,7 @@ class MailView
       missing_format = ext && format.nil?
 
       if actions.include?(name) && !missing_format
-        mail = build_mail(name)
+        mail = build_mail(name, request)
 
         # Requested a specific bare MIME part. Render it verbatim.
         if part_type = request.params['part']
@@ -97,7 +97,7 @@ class MailView
       end
     end
 
-    def build_mail(name)
+    def build_mail(name, request)
       mail = send(name)
       Mail.inform_interceptors(mail) if defined? Mail
       mail


### PR DESCRIPTION
This makes it easy to access the request object (and therefore the URL params, headers, etc) in actions by overloading the default #build_mail and handling the second (request) parameter.

This is related to #50, but is more lightweight and puts access to the params at the business logic layer (where they more properly belong) instead of the template layer.

This commit does not change the API or impact existing functionality.
