### PR TITLE
Properly display utf-8

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html><head>
 <meta name="viewport" content="width=device-width" />
+<meta charset="utf-8">
 <style type="text/css">
   header {
     width: 100%;


### PR DESCRIPTION
This fixis displaying no english letters.

"StaÃ°festing Ã¡ pÃ¶ntun" becomes "Staðfesting á pöntun"
