### PR TITLE
Fix gemspec files when is vendorized with bundler

### DIFF
--- a/mail_view.gemspec
+++ b/mail_view.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'tmail',     '~> 1.2'
   s.add_development_dependency 'rake'
 
-  s.files = Dir["#{File.dirname(__FILE__)}/**/*"]
+  s.files = `git ls-files`.split($/)
 end


### PR DESCRIPTION
When the gem is vendorized

for example:
s.files = ["/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/init.rb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/Rakefile", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/Gemfile", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/Gemfile.lock", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/README.md", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/LICENSE", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib/mail_view.rb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib/mail_view", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib/mail_view/email.html.erb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib/mail_view/index.html.erb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/lib/mail_view/mapper.rb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/test", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/test/test_mail_view.rb", "/home/csaura/projects/my-project/vendor/cache/mail_view-35ca575d6fa4/mail_view.gemspec"]
