### PR TITLE
Remove nil from format options

### DIFF
--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -105,7 +105,7 @@ class MailView
 
     def find_preferred_part(mail, formats)
       found = nil
-      formats.find { |f| found = find_part(mail, f) }
+      formats.compact.find { |f| found = find_part(mail, f) }
       found || mail
     end
 

--- a/test/test_mail_view.rb
+++ b/test/test_mail_view.rb
@@ -61,7 +61,7 @@ class TestMailView < Test::Unit::TestCase
       end
     end
 
-    def multipart_alternative_text_default
+    def multipart_alternative_html_default
       Mail.new do
         to 'josh@37signals.com'
 
@@ -252,13 +252,13 @@ class TestMailView < Test::Unit::TestCase
     assert_equal 'This is plain text', last_response.body
   end
 
-  def test_multipart_alternative_text_as_default
-    get '/multipart_alternative_text_default'
+  def test_multipart_alternative_html_as_default
+    get '/multipart_alternative_html_default'
     assert last_response.ok?
-    assert_match iframe_src_match('text/plain'), last_response.body
+    assert_match iframe_src_match('text/html'), last_response.body
     assert_match 'View as', last_response.body
 
-    get '/multipart_alternative_text_default?part=text%2Fplain'
+    get '/multipart_alternative_html_default?part=text%2Fplain'
     assert last_response.ok?
     assert_equal 'This is plain text', last_response.body
   end


### PR DESCRIPTION
When the format is not specified, the formats array includes nil `[nil, "text/html", "text/plain"]`. `find_part` with a `nil` format will bring back the plain text version. So if a format isn't specified, we remove before we find the preferred format.
