### PR TITLE
Update README to point to the correct git repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install
 Add the gem to your `Gemfile`:
 
 ```ruby
-  gem 'mail_view', :git => 'https://github.com/37signals/mail_view.git'
+  gem 'mail_view', :git => 'https://github.com/basecamp/mail_view.git'
   # or
   gem "mail_view", "~> 2.0.4"
 ```


### PR DESCRIPTION
As 37signals renamed to Basecamp and changed their Github organisation accordingly.
