### PR TITLE
Wrapping mail generation in rolled-back transaction to prevent database changes from persisting

### DIFF
--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -100,10 +100,12 @@ class MailView
     def build_mail(name)
       mail = nil
       ActiveRecord::Base.transaction do
+
         mail = send(name)
+        Mail.inform_interceptors(mail) if defined? Mail
+
         raise ActiveRecord::Rollback
       end
-      Mail.inform_interceptors(mail) if defined? Mail
       mail
     end
 

--- a/lib/mail_view.rb
+++ b/lib/mail_view.rb
@@ -98,7 +98,11 @@ class MailView
     end
 
     def build_mail(name)
-      mail = send(name)
+      mail = nil
+      ActiveRecord::Base.transaction do
+        mail = send(name)
+        raise ActiveRecord::Rollback
+      end
       Mail.inform_interceptors(mail) if defined? Mail
       mail
     end


### PR DESCRIPTION
I use factories for specs and I find them very convenient to use in mail_view's "actions".
Factories — as well as other methods for generating sample data on the fly — need to be cleaned after.
Since mail_view is supposed to be read-only, I see no disadvantage in actual prevention of data changes persistency  — using transactions.

The first commit is kinda working draft for discussion, I'll add specs+docs if needed.

p.s. I've seen #69 but did neither like the solution nor understand the discussion there.

slightly-off-topic: Might be useful to include in the docs: [mail_view for human — and also for automatic — testing](http://mines.mouldwarp.com/2014/03/mailview-for-human-and-also-for.html).
