### PR TITLE
Let the email preview iframe resize to fit the browser window size

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -2,6 +2,10 @@
 <html><head>
 <meta name="viewport" content="width=device-width" />
 <style type="text/css">
+  html, body, iframe {
+    height: 100%;
+  }
+
   body {
     margin: 0;
   }
@@ -38,7 +42,6 @@
   iframe {
     border: 0;
     width: 100%;
-    height: 800px;
   }
 </style>
 </head>


### PR DESCRIPTION
On larger screens the email preview iframe is being limited to a height of 800 pixels, and the full available screen size is not being used.
