### PR TITLE
Add license to gemspec

### DIFF
--- a/mail_view.gemspec
+++ b/mail_view.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |s|
   s.email = 'josh@joshpeek.com'
   s.summary = 'Visual email testing'
   s.homepage = 'https://github.com/37signals/mail_view'
+  s.license = 'MIT'
 
   s.add_dependency 'tilt'
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
