### PR TITLE
Set charset of the e-mail preview page

### DIFF
--- a/lib/mail_view/email.html.erb
+++ b/lib/mail_view/email.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html><head>
 <meta name="viewport" content="width=device-width" />
+<meta charset="UTF-8" />
 <style type="text/css">
   body {
     margin: 0;


### PR DESCRIPTION
the e-mail subject will not be displayed correctly if it's not in english

before:

![screen shot 2015-12-16 at 11 47 44 am](https://cloud.githubusercontent.com/assets/1770351/11837649/ecbc1846-a3ea-11e5-8848-fed4fb4ec466.png)

after:

![screen shot 2015-12-16 at 11 47 54 am](https://cloud.githubusercontent.com/assets/1770351/11837652/f1c3f3ae-a3ea-11e5-97df-bde46df302f0.png)
